### PR TITLE
don't shadow `word` variable

### DIFF
--- a/script.js
+++ b/script.js
@@ -198,7 +198,7 @@ function checkWord() {
 		var resultText = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x-circle" viewBox="0 0 16 16">
 		<path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/>
 		<path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708"/>
-	  </svg>Word is not a valid word.`;
+	  </svg> ${word} is not a valid word.`;
 		var resultColor = "red";
 		var element = document.getElementById("resultText");
 		element.innerHTML = resultText;
@@ -215,8 +215,7 @@ function callAPI(word) {
 
 	var response = fetch(apiURL, {
 		method: "GET",
-	}).then(function (response, word) {
-		var word = word;
+	}).then(function(response) {
 		if (response.status == 200) {
 			var resultText = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check-circle" viewBox="0 0 16 16">
 			<path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/>
@@ -227,7 +226,7 @@ function callAPI(word) {
 			var resultText = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x-circle" viewBox="0 0 16 16">
 			<path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/>
 			<path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708"/>
-		  </svg>Word is not a valid word.`;
+		  </svg> ${word} is not a valid word.`;
 			var resultColor = "red";
 		} else {
 			var resultText = `We encountered an error. Please try again`;


### PR DESCRIPTION
this allows the original `word` value to be used in the error messages